### PR TITLE
ci: add coverage and pin actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,18 @@ jobs:
       - name: Mypy (type check)
         run: mypy src
       - name: Pytest
-        run: pytest
+        run: pytest --cov-fail-under=70
       - name: Show coverage summary
         if: always()
         run: |
           if [ -f coverage.xml ]; then grep -E 'line-rate' coverage.xml || true; fi
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
+          flags: unit
+          verbose: true
       # - name: Upload coverage artifact (optional)
       #   uses: actions/upload-artifact@<pin-sha>
       #   with:


### PR DESCRIPTION
### **User description**
Adds coverage enforcement (70% threshold) and uploads coverage to Codecov using a pinned action commit for supply-chain security. Also pins previously added actions (checkout, setup-python) and maintains least-privilege permissions. Steps:
- Add --cov-fail-under=70 flag to pytest invocation.
- Add Codecov upload step pinned to commit b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 (v4).
- Preserve existing pinned SHAs for actions/checkout and actions/setup-python.
- Keep permissions scoped to contents: read only.

Security rationale:
- Pinning actions prevents tag drift.
- Minimal token permissions reduce blast radius.

Next possible improvements:
- Pin upload-artifact if artifact publishing is needed.
- Introduce caching for pip to speed CI.
- Add branch protection requiring the coverage job.

Let me know if you want any of these follow-ups in this PR.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add coverage enforcement with 70% threshold

- Upload coverage reports to Codecov

- Pin Codecov action for supply-chain security


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pytest execution"] -- "add --cov-fail-under=70" --> B["coverage enforcement"]
  B -- "generate coverage.xml" --> C["Codecov upload"]
  C -- "pinned action SHA" --> D["secure CI pipeline"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add coverage enforcement and Codecov integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add <code>--cov-fail-under=70</code> flag to pytest command for coverage <br>enforcement<br> <li> Add Codecov upload step using pinned action commit SHA<br> <li> Configure Codecov with fail_ci_if_error, flags, and verbose options</ul>


</details>


  </td>
  <td><a href="https://github.com/Maverick0351a/signet-pqc-control-plane/pull/1/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

